### PR TITLE
Rename `matchI` to `matchItem`

### DIFF
--- a/ADT.ts
+++ b/ADT.ts
@@ -57,13 +57,13 @@ export function match<ADT extends { _type: string }, Z>(
  * ```ts
  * declare const foo: Option<string>
  *
- * matchI(foo)({
+ * matchItem(foo)({
  *   none: () => 'none',
  *   some: ({value}) => 'some'
  * })
  * ```
  */
-export function matchI<ADT extends { _type: string }>(
+export function matchItem<ADT extends { _type: string }>(
   v: ADT
 ): <Z>(matchObj: { [K in ADT["_type"]]: (v: ADTMember<ADT, K>) => Z }) => Z {
   return (matchObj) => (matchObj as any)[v._type](v);

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ import { ADT, match, matchI } from 'ts-adt'
 
 declare const userImage: Option<string>
 
-const img = matchI(userImage)({
+const img = matchItem(userImage)({
   some: ({value}) => value,
   none: () => "http://example.com/defaultImage"
 })


### PR DESCRIPTION
Hello!

Thanks for the effort of creating this library, it is very useful 😃

I'm proposing here renaming `matchI` to `matchItem` as in larger teams with many people, `matchI` is not obvious at first sight, in fact I had to get into the library code to understand what was going on.

I think that this change would help many people adopting the library, thanks again!