### PR TITLE
Added support for using underscore for partial matchers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 lib
+**/*.test.js

--- a/ADT.ts
+++ b/ADT.ts
@@ -51,6 +51,30 @@ export type ADTMember<ADT, Type extends string> = Omit<
  * ```
  */
 export function match<ADT extends { _type: string }, Z>(
+  matchObj: MatchObj<ADT, Z>
+): (v: ADT) => Z {
+  return (v) =>
+    (matchObj as any)[v._type] != null
+      ? (matchObj as any)[v._type](v)
+      : (matchObj as any)["_"](v);
+}
+
+/**
+ * Partial pattern matching for a sum type defined with ADT
+ *
+ * ```ts
+ * declare const foo: Option<string>
+ *
+ * pipe(
+ *   foo,
+ *   match({
+ *     some: ({value}) => 'some'
+ *     _: (_option) => 'none',
+ *   })
+ * )
+ * ```
+ */
+export function matchP<ADT extends { _type: string }, Z>(
   matchObj: MatchObj<ADT, Z> | PartialMatchObj<ADT, Z>
 ): (v: ADT) => Z {
   return (v) =>
@@ -77,7 +101,19 @@ export function matchI<ADT extends { _type: string }>(
   return (matchObj) => (matchObj as any)[v._type](v);
 }
 
-export function matchP<ADT extends { _type: string }>(
+/**
+ * Item-first version of matchP, useful for better inference in some circumstances
+ *
+ * ```ts
+ * declare const foo: Option<string>
+ *
+ * matchP(foo)({
+ *   some: ({value}) => 'some'
+ *   _: (_option) => 'none',
+ * })
+ * ```
+ */
+export function matchPI<ADT extends { _type: string }>(
   v: ADT
 ): <Z>(matchObj: MatchObj<ADT, Z> | PartialMatchObj<ADT, Z>) => Z {
   return (matchObj) =>

--- a/ADT.ts
+++ b/ADT.ts
@@ -19,16 +19,13 @@ export type ADT<T extends Record<string, {}>> = {
   [K in keyof T]: K extends "_" ? never : { _type: K } & T[K];
 }[keyof T];
 
-// Omit type, for TS < 3.5
-type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
-
 type MatchObj<ADT extends { _type: string }, Z> = {
   [K in ADT["_type"]]: (v: ADTMember<ADT, K>) => Z;
 };
 
 type PartialMatchObj<ADT extends { _type: string }, Z> = Partial<
   MatchObj<ADT, Z>
-> & { _: () => Z };
+> & { _: (v: ADT) => Z };
 
 /**
  * Helper type for omitting the '_type' field from values
@@ -59,7 +56,7 @@ export function match<ADT extends { _type: string }, Z>(
   return (v) =>
     (matchObj as any)[v._type] != null
       ? (matchObj as any)[v._type](v)
-      : (matchObj as any)["_"]();
+      : (matchObj as any)["_"](v);
 }
 
 /**
@@ -76,9 +73,15 @@ export function match<ADT extends { _type: string }, Z>(
  */
 export function matchI<ADT extends { _type: string }>(
   v: ADT
+): <Z>(matchObj: MatchObj<ADT, Z>) => Z {
+  return (matchObj) => (matchObj as any)[v._type](v);
+}
+
+export function matchP<ADT extends { _type: string }>(
+  v: ADT
 ): <Z>(matchObj: MatchObj<ADT, Z> | PartialMatchObj<ADT, Z>) => Z {
   return (matchObj) =>
     (matchObj as any)[v._type] != null
       ? (matchObj as any)[v._type](v)
-      : (matchObj as any)["_"]();
+      : (matchObj as any)["_"](v);
 }

--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ const img = pipe(
 
 Both functions work the same way, but their arguments are ordered differently for better inference in different cases.
 
+You can also use an underscore if you don't need to match against all possible cases:
+
+```ts
+type PrettyPlease<A> = ADT<{
+  idle: {};
+  workingOnIt: {};
+  success: { value: A };
+  failure: { error: Error };
+}>;
+
+declare const promise: PrettyPlease<string>;
+
+matchI(promise)({
+  success: (_) => _.value,
+  _: () => "Wait or come back later.",
+});
+```
+
 
 
 

--- a/adt.test.ts
+++ b/adt.test.ts
@@ -1,8 +1,8 @@
-import { ADT, matchI, match } from "./ADT";
+import { ADT, matchI, matchP, match } from "./ADT";
 
 type UnderScoreAsTagAttempt<A> = ADT<{
   good: { value: A };
-  _: { value: "NEVER" };
+  _: { value: "NEVER!" };
 }>;
 
 declare const underScoreAsTagAttempt: UnderScoreAsTagAttempt<string>;
@@ -50,22 +50,54 @@ matchI(promise)({
 });
 
 matchI(promise)({
-    idle: (_) => "I'm lazy",
-    workingOnIt: (_) => "Soon!",
-    success: (_) => _.value,
-    failure: (_) => `${_.error}`,
-    // Only known types are allowed.
-    // @ts-expect-error
-    stale: _ => "Old news"
-  });
+  idle: (_) => "I'm lazy",
+  workingOnIt: (_) => "Soon!",
+  success: (_) => _.value,
+  failure: (_) => `${_.error}`,
+  // Only known types are allowed.
+  // @ts-expect-error
+  stale: (_) => "Old news",
+});
 
+// matchI can't match a subset but must match all cases
 // @ts-expect-error
 matchI(promise)({
   workingOnIt: (_) => "Soon!",
   success: (_) => _.value,
 });
 
+// matchI must match against all possible cases
+matchI(promise)({
+  idle: () => "Start baking!",
+  workingOnIt: (_) => "... Tempering",
+  success: (_) => _.value,
+  failure: (_) => "Oops!",
+});
+
+// matchI must not support partial matching
 matchI(promise)({
   success: (_) => _.value,
-  _: () => "Wait or come back later.",
+  // @ts-expect-error
+  _: (value) => "Wait or come back later.",
+});
+
+matchP(promise)({
+  success: (_) => _.value,
+  _: (value) => "Wait or come back later.",
+});
+
+// matchP can't match against unknown cases
+matchP(promise)({
+  success: (_) => _.value,
+  // @ts-expect-error
+  stale: (_) => "Old news",
+  _: (value) => "Wait or come back later.",
+});
+
+// matchP should allow matching against all cases
+matchP(promise)({
+  idle: () => "Start baking!",
+  workingOnIt: (_) => "... Tempering",
+  success: (_) => _.value,
+  failure: (_) => "Oops!",
 });

--- a/adt.test.ts
+++ b/adt.test.ts
@@ -1,0 +1,71 @@
+import { ADT, matchI, match } from "./ADT";
+
+type UnderScoreAsTagAttempt<A> = ADT<{
+  good: { value: A };
+  _: { value: "NEVER" };
+}>;
+
+declare const underScoreAsTagAttempt: UnderScoreAsTagAttempt<string>;
+
+// Does not fail since the original underscore was excluded.
+matchI(underScoreAsTagAttempt)({
+  good: (_) => _.value,
+});
+
+type PrettyPlease<A> = ADT<{
+  idle: {};
+  workingOnIt: {};
+  success: { value: A };
+  failure: { error: Error };
+}>;
+
+declare const promise: PrettyPlease<"Chocolate">;
+
+// Testing match
+match<typeof promise, string>({
+  idle: (_) => "I'm lazy",
+  workingOnIt: (_) => "Soon!",
+  success: (_) => _.value,
+  failure: (_) => `${_.error}`,
+})(promise);
+
+// @ts-expect-error
+match<typeof promise, string>({
+  workingOnIt: (_) => "Soon!",
+  success: (_) => _.value,
+})(promise);
+
+match<typeof promise, string>({
+  success: (_) => _.value,
+  _: () => "Wait or come back later.",
+})(promise);
+
+// Testing matchI
+
+matchI(promise)({
+  idle: (_) => "I'm lazy",
+  workingOnIt: (_) => "Soon!",
+  success: (_) => _.value,
+  failure: (_) => `${_.error}`,
+});
+
+matchI(promise)({
+    idle: (_) => "I'm lazy",
+    workingOnIt: (_) => "Soon!",
+    success: (_) => _.value,
+    failure: (_) => `${_.error}`,
+    // Only known types are allowed.
+    // @ts-expect-error
+    stale: _ => "Old news"
+  });
+
+// @ts-expect-error
+matchI(promise)({
+  workingOnIt: (_) => "Soon!",
+  success: (_) => _.value,
+});
+
+matchI(promise)({
+  success: (_) => _.value,
+  _: () => "Wait or come back later.",
+});

--- a/adt.test.ts
+++ b/adt.test.ts
@@ -1,4 +1,4 @@
-import { ADT, matchI, matchP, match } from "./ADT";
+import { ADT, matchI, matchPI, match, matchP } from "./ADT";
 
 type UnderScoreAsTagAttempt<A> = ADT<{
   good: { value: A };
@@ -21,7 +21,9 @@ type PrettyPlease<A> = ADT<{
 
 declare const promise: PrettyPlease<"Chocolate">;
 
-// Testing match
+/**
+ * match
+ */
 match<typeof promise, string>({
   idle: (_) => "I'm lazy",
   workingOnIt: (_) => "Soon!",
@@ -35,13 +37,26 @@ match<typeof promise, string>({
   success: (_) => _.value,
 })(promise);
 
+// match should not allow partial matching
 match<typeof promise, string>({
+  success: (_) => _.value,
+  // @ts-expect-error
+  _: () => "Wait or come back later.",
+})(promise);
+
+/**
+ * matchP
+ */
+
+// matchP allows partial matching
+matchP<typeof promise, string>({
   success: (_) => _.value,
   _: () => "Wait or come back later.",
 })(promise);
 
-// Testing matchI
-
+/**
+ * matchI
+ */
 matchI(promise)({
   idle: (_) => "I'm lazy",
   workingOnIt: (_) => "Soon!",
@@ -81,21 +96,24 @@ matchI(promise)({
   _: (value) => "Wait or come back later.",
 });
 
-matchP(promise)({
+/**
+ * matchPI
+ */
+matchPI(promise)({
   success: (_) => _.value,
   _: (value) => "Wait or come back later.",
 });
 
-// matchP can't match against unknown cases
-matchP(promise)({
+// matchPI can't match against unknown cases
+matchPI(promise)({
   success: (_) => _.value,
   // @ts-expect-error
   stale: (_) => "Old news",
   _: (value) => "Wait or come back later.",
 });
 
-// matchP should allow matching against all cases
-matchP(promise)({
+// matchPI should allow matching against all cases
+matchPI(promise)({
   idle: () => "Start baking!",
   workingOnIt: (_) => "... Tempering",
   success: (_) => _.value,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "ts-adt",
+  "version": "1.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "typescript": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "test": "tsc adt.test.ts"
   },
   "devDependencies": {
-    "typescript": "3.9"
+    "typescript": "^4.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc",
-    "prepublish": "tsc"
+    "prepublish": "tsc",
+    "test": "tsc adt.test.ts"
   },
   "devDependencies": {
     "typescript": "3.9"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "prepublish": "tsc"
   },
   "devDependencies": {
-    "typescript": "3.7"
+    "typescript": "3.9"
   }
 }


### PR DESCRIPTION
```ts
// example.ts

type PrettyPlease<A> = ADT<{
  idle: {};
  workingOnIt: {};
  success: { value: A };
  failure: { error: Error };
}>;

declare const promise: PrettyPlease<"Chocolate">;

matchI(promise)({
  success: (_) => _.value,
  _: () => "Wait or come back later.",
});
```

I've also added a test file to ensure the type safety persisted. `type ADT` will also remove underscore types to prevent conflicts. I upgraded TypeScript so that I could make use of _@ts-expect-error_ in the test file.