### PR TITLE
change _type to _tag

### DIFF
--- a/ADT.ts
+++ b/ADT.ts
@@ -16,18 +16,18 @@
  * ```
  */
 export type ADT<T extends Record<string, {}>> = {
-  [K in keyof T]: { _type: K } & T[K];
+  [K in keyof T]: { _tag: K } & T[K];
 }[keyof T];
 
 // Omit type, for TS < 3.5
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 /**
- * Helper type for omitting the '_type' field from values
+ * Helper type for omitting the '_tag' field from values
  */
 export type ADTMember<ADT, Type extends string> = Omit<
-  Extract<ADT, { _type: Type }>,
-  "_type"
+  Extract<ADT, { _tag: Type }>,
+  "_tag"
 >;
 
 /**
@@ -45,10 +45,10 @@ export type ADTMember<ADT, Type extends string> = Omit<
  * )
  * ```
  */
-export function match<ADT extends { _type: string }, Z>(
-  matchObj: { [K in ADT["_type"]]: (v: ADTMember<ADT, K>) => Z }
+export function match<ADT extends { _tag: string }, Z>(
+  matchObj: { [K in ADT["_tag"]]: (v: ADTMember<ADT, K>) => Z }
 ): (v: ADT) => Z {
-  return (v) => (matchObj as any)[v._type](v);
+  return (v) => (matchObj as any)[v._tag](v);
 }
 
 /**
@@ -63,8 +63,8 @@ export function match<ADT extends { _type: string }, Z>(
  * })
  * ```
  */
-export function matchI<ADT extends { _type: string }>(
+export function matchI<ADT extends { _tag: string }>(
   v: ADT
-): <Z>(matchObj: { [K in ADT["_type"]]: (v: ADTMember<ADT, K>) => Z }) => Z {
-  return (matchObj) => (matchObj as any)[v._type](v);
+): <Z>(matchObj: { [K in ADT["_tag"]]: (v: ADTMember<ADT, K>) => Z }) => Z {
+  return (matchObj) => (matchObj as any)[v._tag](v);
 }

--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ type Option<A> = ADT<{
 
 This translates to:
 ```ts
-type Option<A> = { _type: 'some', value: A} | { _type: 'none' }
+type Option<A> = { _tag: 'some', value: A} | { _tag: 'none' }
 ```
 
-Here, `Option<A>` represents a value that can be one of two types; either it's an object with a `_type` attribute `"some"` _and_ a value `A`, or it's an object with `_type` attribute `"none"`. This type is quite useful, especially when used with Typescript's type narrowing feature:
+Here, `Option<A>` represents a value that can be one of two types; either it's an object with a `_tag` attribute `"some"` _and_ a value `A`, or it's an object with `_tag` attribute `"none"`. This type is quite useful, especially when used with Typescript's type narrowing feature:
 
 ```ts
 declare const userImage: Option<string>
 
 function getUserImage(): string {
-  if(userImage._type === 'some') {
-    return userImage.value // value is accessible here, since _type is 'some'
+  if(userImage._tag === 'some') {
+    return userImage.value // value is accessible here, since _tag is 'some'
   } else {
     return "http://example.com/defaultImage" 
   }


### PR DESCRIPTION
I use this package side-by-side by fp-ts and under the hood fp-ts is using `_tag` as type signature. See [this](https://github.com/gcanti/fp-ts/blob/master/src/Option.ts#L45). 