### PR TITLE
Add a default `otherwise` to PI matcher

### DIFF
--- a/src/MakeADT.ts
+++ b/src/MakeADT.ts
@@ -160,7 +160,7 @@ export function makeMatchPI<D extends string>(
   F extends (rest: Exclude<ADT, {[K in D]: keyof M}>) => unknown
 >(
   matchObj: M,
-  otherwise: F
+  otherwise: F = (v) => v
 ) => MakePartialReturns<D, ADT, M> | ReturnType<F> {
   return (v) => (matchObj, otherwise) =>
     matchObj[v[d]] != null


### PR DESCRIPTION
If we only want to modify a specific branch leaving the other intact this reduces boilerplate.
This can come up very often for example with an Optional ADT if we chain modifying 
`Some` values leaving `None` intact.

We can write:
```typescript
const result = matchPI(a)({
  Ok: ({ value }) => ({ value: `Cool: ${value}` }),
});
```

instead of

```typescript
const result = matchPI(a)({
  Ok: ({ value }) => ({ value: `Cool: ${value}` }),
}, (v) => v);
```

> I'm sorry for the newline change at the end. I've used GitHub for editing the file and it did that automatically. Please let me know if you want me to fix that.

> I have not run any test on this change yet. It's possible there are other parts of code that need changing? Let me know if I missed something.

> Finally thank you for this library! I find it very useful in creating simple Optional/Result etc. data types ❤️ 